### PR TITLE
fix gaps padding margins on form element, logo

### DIFF
--- a/src/components/DevInput.tsx
+++ b/src/components/DevInput.tsx
@@ -14,8 +14,8 @@ const DevInput: React.FC<Props> = ({ className, title, ...props }) => {
 			{title && <label className="mb-1 block font-medium">{title}</label>}
 			<input
 				{...props}
-				className={`bg-light-200 border-0 rounded-lg h-[48px] px-3 block ${className}`}
-			></input>
+				className={`bg-light-200 border-0 rounded-lg px-4 py-2 md:px-5 md:py-3  lg:px-6 lg:py-3 block ${className}`}
+			/>
 		</>
 	);
 };

--- a/src/components/StayConnectedBanner.tsx
+++ b/src/components/StayConnectedBanner.tsx
@@ -6,7 +6,7 @@ interface Props extends React.HTMLProps<HTMLDivElement> {
 const StayConnectedBanner: React.FC<Props> = ({ className, ...props }) => {
 	return (
 		<div
-			className={`flex justify-center md:min-h-screen items-center bg-light-100 text-accent-200 lg:bg-accent-200 lg:text-light-100 lg:overflow-hidden ${className}`}
+			className={`flex justify-center md:min-h-screen items-center bg-light-100 text-accent-200 md:text-white md:bg-accent-200 lg:overflow-hidden ${className}`}
 			{...props}
 		>
 			<div
@@ -18,7 +18,7 @@ const StayConnectedBanner: React.FC<Props> = ({ className, ...props }) => {
 					Share Your <br /> Interests, <br />
 					Stay
 				</span>
-				<span className="bg-dark-200 mt-3 text-center flex items-center justify-center -rotate-[5.2deg] text-light-100 w-fit px-2 py-2 lg:py-6 lg:px-4">
+				<span className="bg-dark-200 mt-3 text-center flex items-center justify-center -rotate-[5.2deg] text-light-100 w-fit px-3 py-2 lg:py-6 lg:px-4">
 					Connected.
 				</span>
 			</div>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -9,24 +9,25 @@ const SignUp: React.FC = () => {
 		<div className="p-5 md:p-0 flex flex-col bg-light-100 min-h-screen md:flex-row">
 			<Logo className="mb-10 md:hidden text-accent-200" />
 			<StayConnectedBanner type="accent" className="mb-20 md:mb-0 md:w-1/2" />
-			<div className="md:w-1/2 md:pl-20 md:bg-accent-200 lg:bg-light-100 md:text-light-100 lg:text-dark-200">
-				<Logo className="mb-20 mt-32 mx-auto hidden md:block lg:text-accent-200" />
-				<form action="">
+			<div className="md:w-1/2 md:pl-20 text-dark-200">
+				<Logo className="my-2 lg:my-4 xl:my-8 mx-auto hidden md:block lg:text-accent-200" />
+				<form className="flex flex-col gap-1 pb-2">
+					<h2 className="font-bold mb-4 capitalize text-dark-200 text-xl">Sign up</h2>
 					<DevInput
 						title="User Name"
-						className="mb-3 w-full md:w-9/12 2xl:w-6/12 text-black"
+						className="mb-3 w-full md:w-9/12 2xl:w-6/12 text-dark-200"
 					/>
 					<DevInput
 						title="Email Address"
-						className="mb-3 w-full md:w-9/12 2xl:w-6/12 text-black"
+						className="mb-3 w-full md:w-9/12 2xl:w-6/12 text-dark-200"
 					/>
 					<DevInput
 						title="Password"
-						className="mb-3 w-full md:w-9/12 2xl:w-6/12 text-black"
+						className="mb-3 w-full md:w-9/12 2xl:w-6/12 text-dark-200"
 					/>
 					<DevInput
 						title="Confirm Password"
-						className="w-full md:w-9/12 2xl:w-6/12 text-black"
+						className="w-full md:w-9/12 2xl:w-6/12 text-dark-200"
 					/>
 					<DevButton
 						type="secondary"
@@ -37,7 +38,7 @@ const SignUp: React.FC = () => {
 					<div className="mt-3">
 						Do you have an account?
 						<Link to="/login">
-							<span className="text-accent-200 md:text-light-200 lg:text-accent-200 font-medium cursor-pointer">
+							<span className="text-accent-200 font-medium cursor-pointer">
 								{" "}
 								Login
 							</span>


### PR DESCRIPTION
- Added some gaps between the form elements.
- Fixed extra margins on logo component.
- Remove the fixed height on the input element and added padding instead.
- Accent color now is fixed as a background to the connected side instead of switching to the other side on tablets that was my bad in the Figam prototype